### PR TITLE
Fix SortableJS integrity and provide inline favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,13 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Micrositio educativo</title>
+  <link
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%231f6feb'/%3E%3Cpath d='M20 20h24v8H20zm0 12h24v12H20z' fill='%23ffb454'/%3E%3C/svg%3E"
+  />
   <link rel="stylesheet" href="style.css" />
-  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js" integrity="sha384-5aCkNvztNFVQVw1Gc7YCOUMIqFZ3VAbwYSEuxsjjXNMTvEihQ/HUkNzxaz2QmiFj" crossorigin="anonymous" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js" integrity="sha384-BSxuMLxX+FCbTdYec3TbXlnMGEEM2QXTFdtDaveen71o+jswm2J36+xFqp8k4VHM" crossorigin="anonymous" defer></script>
   <script src="app.js" defer></script>
 </head>
 <body data-mode="auto">


### PR DESCRIPTION
## Summary
- correct the SortableJS CDN integrity hash so the drag and drop script loads
- embed a lightweight SVG favicon via data URI to stop 404 errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9bc3a30988333a341131a42db0c77