### PR TITLE
Fix SortableJS CDN integrity

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,12 @@
     href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%231f6feb'/%3E%3Cpath d='M20 20h24v8H20zm0 12h24v12H20z' fill='%23ffb454'/%3E%3C/svg%3E"
   />
   <link rel="stylesheet" href="style.css" />
-  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js" integrity="sha384-BSxuMLxX+FCbTdYec3TbXlnMGEEM2QXTFdtDaveen71o+jswm2J36+xFqp8k4VHM" crossorigin="anonymous" defer></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/dist/sortable.umd.min.js"
+    integrity="sha384-h6xgbFAgGt4VcVls6SlA/yYVW8zNOUk+AO9WJN6taCaluYEa3p7V+zu50J0zh2iC"
+    crossorigin="anonymous"
+    defer
+  ></script>
   <script src="app.js" defer></script>
 </head>
 <body data-mode="auto">


### PR DESCRIPTION
## Summary
- point the SortableJS CDN script tag to the dist UMD bundle
- update the subresource integrity hash so the script loads correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9bd422db48333b839ad5f9171d4fa